### PR TITLE
Add check for fwd ref types

### DIFF
--- a/src/reactionRunner.js
+++ b/src/reactionRunner.js
@@ -26,6 +26,13 @@ export function runAsReaction (reaction, fn, context, args) {
       // set the reaction as the currently running one
       // this is required so that we can create (observable.prop -> reaction) pairs in the get trap
       reactionStack.push(reaction)
+      if (
+        fn.$$typeof === Symbol.for('react.forward_ref') ||
+        fn.render ||
+        (fn.prototype && fn.prototype.render)
+      ) {
+        return Reflect.apply(fn.render || fn.prototype.render, context, args)
+      }
       return Reflect.apply(fn, context, args)
     } finally {
       // always remove the currently running flag from the reaction when it stops execution


### PR DESCRIPTION
This will make `forwardRef`(s) work with `@frontity/react-easy-state` and `@frontity/with-preact`.